### PR TITLE
Optimize PyTorch MPELU CUDA performance

### DIFF
--- a/pytorch/mpelu.cpp
+++ b/pytorch/mpelu.cpp
@@ -1,13 +1,35 @@
 #include "mpelu.h"
 
+namespace {
+
+void check_mpelu_arguments(
+    const torch::Tensor& input,
+    const torch::Tensor& a,
+    const torch::Tensor& b
+) {
+    CHECK_INPUT(input);
+    CHECK_INPUT(a);
+    CHECK_INPUT(b);
+    TORCH_CHECK(input.dim() == 4, "input must be a 4D NCHW tensor");
+    TORCH_CHECK(a.dim() == 1 && b.dim() == 1,
+                "alpha and beta must be 1D channel-wise tensors");
+    TORCH_CHECK(a.numel() == input.size(1) && b.numel() == input.size(1),
+                "alpha and beta must contain one value per input channel");
+    TORCH_CHECK(input.scalar_type() == a.scalar_type() &&
+                input.scalar_type() == b.scalar_type(),
+                "input, alpha, and beta must have the same dtype");
+    TORCH_CHECK(input.device() == a.device() && input.device() == b.device(),
+                "input, alpha, and beta must be on the same CUDA device");
+}
+
+}  // namespace
+
 torch::Tensor mpelu_forward(
     torch::Tensor input,
     torch::Tensor a,
     torch::Tensor b
 ) {
-    CHECK_INPUT(input);
-    CHECK_INPUT(a);
-    CHECK_INPUT(b);
+    check_mpelu_arguments(input, a, b);
 
     return mpelu_forward_cuda(input, a, b);
 }
@@ -16,26 +38,44 @@ void mpelu_backward(
     const torch::Tensor& input,
     const torch::Tensor& a,
     const torch::Tensor& b,
-    const torch::Tensor& output,
     const torch::Tensor& grad_output,
     torch::Tensor& grad_input,
     torch::Tensor& grad_a,
     torch::Tensor& grad_b
 ) {
-    CHECK_INPUT(input);
-    CHECK_INPUT(a);
-    CHECK_INPUT(b);
-    CHECK_INPUT(output);
+    check_mpelu_arguments(input, a, b);
     CHECK_INPUT(grad_output);
     CHECK_INPUT(grad_input);
     CHECK_INPUT(grad_a);
     CHECK_INPUT(grad_b);
 
-    mpelu_backward_cuda(input, a, b, output, grad_output, grad_input, grad_a, grad_b);
+    TORCH_CHECK(grad_output.sizes() == input.sizes(),
+                "grad_output must have the same shape as input");
+    TORCH_CHECK(grad_output.scalar_type() == input.scalar_type(),
+                "grad_output must have the same dtype as input");
+    TORCH_CHECK(grad_output.device() == input.device(),
+                "grad_output must be on the same CUDA device as input");
+    TORCH_CHECK(grad_input.sizes() == input.sizes(),
+                "grad_input must have the same shape as input");
+    TORCH_CHECK(grad_a.sizes() == a.sizes() && grad_b.sizes() == b.sizes(),
+                "parameter gradients must match alpha and beta");
+    const auto accumulation_type = input.scalar_type() == at::kDouble
+        ? at::kDouble
+        : at::kFloat;
+    TORCH_CHECK(grad_input.scalar_type() == input.scalar_type(),
+                "grad_input must have the input dtype");
+    TORCH_CHECK(grad_a.scalar_type() == accumulation_type &&
+                grad_b.scalar_type() == accumulation_type,
+                "parameter gradients must use the accumulation dtype");
+    TORCH_CHECK(grad_input.device() == input.device() &&
+                grad_a.device() == input.device() &&
+                grad_b.device() == input.device(),
+                "all output gradients must be on the input CUDA device");
+
+    mpelu_backward_cuda(input, a, b, grad_output, grad_input, grad_a, grad_b);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m){
     m.def("mpelu_forward", &mpelu_forward);
     m.def("mpelu_backward", &mpelu_backward);
 }
-

--- a/pytorch/mpelu.h
+++ b/pytorch/mpelu.h
@@ -15,7 +15,6 @@ void mpelu_backward_cuda(
     const torch::Tensor& input,
     const torch::Tensor& a,
     const torch::Tensor& b,
-    const torch::Tensor& output,
     const torch::Tensor& grad_output,
     torch::Tensor& grad_input,
     torch::Tensor& grad_a,

--- a/pytorch/mpelu.py
+++ b/pytorch/mpelu.py
@@ -6,8 +6,15 @@ class MPELUFunction(torch.autograd.Function):
     @staticmethod
     @custom_fwd
     def forward(ctx, input, alpha, beta):
-        output = mpelu_cuda.mpelu_forward(input, alpha.to(input.dtype), beta.to(input.dtype))
-        ctx.save_for_backward(input, alpha, beta, output)
+        input_contiguous = input.contiguous()
+        alpha_compute = alpha.to(dtype=input.dtype).contiguous()
+        beta_compute = beta.to(dtype=input.dtype).contiguous()
+        output = mpelu_cuda.mpelu_forward(
+            input_contiguous, alpha_compute, beta_compute
+        )
+        ctx.save_for_backward(input_contiguous, alpha_compute, beta_compute)
+        ctx.alpha_dtype = alpha.dtype
+        ctx.beta_dtype = beta.dtype
 
         return output
 
@@ -15,16 +22,24 @@ class MPELUFunction(torch.autograd.Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_output):
-        input, alpha, beta, output = ctx.saved_tensors
-        alpha = alpha.to(input.dtype)
-        beta = beta.to(input.dtype)
-        grad_input = torch.zeros_like(input)
-        grad_a = torch.zeros_like(alpha)
-        grad_b = torch.zeros_like(beta)
+        input, alpha, beta = ctx.saved_tensors
+        grad_output = grad_output.contiguous()
+        grad_input = torch.empty_like(input)
+        accumulation_dtype = (
+            torch.float64 if input.dtype == torch.float64 else torch.float32
+        )
+        grad_a = torch.zeros_like(alpha, dtype=accumulation_dtype)
+        grad_b = torch.zeros_like(beta, dtype=accumulation_dtype)
 
-        mpelu_cuda.mpelu_backward(input, alpha, beta, output, grad_output.contiguous(), grad_input.contiguous(), grad_a.contiguous(), grad_b.contiguous())
+        mpelu_cuda.mpelu_backward(
+            input, alpha, beta, grad_output, grad_input, grad_a, grad_b
+        )
         
-        return grad_input, grad_a, grad_b
+        return (
+            grad_input,
+            grad_a.to(dtype=ctx.alpha_dtype),
+            grad_b.to(dtype=ctx.beta_dtype),
+        )
 
 
 class MPELU(torch.nn.Module):

--- a/pytorch/mpelu_kernel.cu
+++ b/pytorch/mpelu_kernel.cu
@@ -1,168 +1,186 @@
 #include <torch/extension.h>
+
+#include <ATen/AccumulateType.h>
 #include <ATen/cuda/Atomic.cuh>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <algorithm>
+
+namespace {
+
+constexpr int kThreads = 256;
 
 template <typename scalar_t>
 __global__ void mpelu_forward_cuda_kernel(
-    const torch::PackedTensorAccessor<scalar_t, 4, torch::RestrictPtrTraits, size_t> input,
-    const torch::PackedTensorAccessor<scalar_t, 1, torch::RestrictPtrTraits, size_t> a,
-    const torch::PackedTensorAccessor<scalar_t, 1, torch::RestrictPtrTraits, size_t> b,
-    torch::PackedTensorAccessor<scalar_t, 4, torch::RestrictPtrTraits, size_t> output,
-    const int width, const int height
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ alpha,
+    const scalar_t* __restrict__ beta,
+    scalar_t* __restrict__ output,
+    int64_t num_elements,
+    int64_t channels,
+    int64_t spatial_size
 ) {
-    const int batch_idx = blockIdx.z;
-    const int channel_idx = blockIdx.y;
-    const int pixel_idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (pixel_idx < width * height) {
-        int x = pixel_idx % width;
-        int y = pixel_idx / width;
-
-        scalar_t in_val = input[batch_idx][channel_idx][y][x];
-        if (in_val < 0) {
-            output[batch_idx][channel_idx][y][x] = a[channel_idx] * (exp(b[channel_idx] * in_val) - 1);
-        } else {
-            output[batch_idx][channel_idx][y][x] = in_val;
-        }
+    using acc_t = at::acc_type<scalar_t, true>;
+    for (int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
+         index < num_elements;
+         index += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+        const int64_t channel = (index / spatial_size) % channels;
+        const acc_t value = static_cast<acc_t>(input[index]);
+        const acc_t result = value > acc_t(0)
+            ? value
+            : static_cast<acc_t>(alpha[channel]) *
+                (exp(static_cast<acc_t>(beta[channel]) * value) - acc_t(1));
+        output[index] = static_cast<scalar_t>(result);
     }
 }
 
-/*
-=============== Solution 1 for atomicAdd not support for (c10::Half *, c10::Half) ===============
-adapted from https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh
-https://forums.developer.nvidia.com/t/atomicadd-not-overloaded-for-c10-half/204474/2
-__device__ __forceinline__ void atomicAdd(c10::Half* address, c10::Half val) {
-    unsigned int *address_as_ui = reinterpret_cast<unsigned int *>(reinterpret_cast<char *>(address) - (reinterpret_cast<size_t>(address) & 2));
-    unsigned int old = *address_as_ui;
-    unsigned int assumed;
-
-    do {
-        assumed = old;
-        unsigned short hsum = reinterpret_cast<size_t>(address) & 2 ? (old >> 16) : (old & 0xffff);
-        hsum += val;
-        old = reinterpret_cast<size_t>(address) & 2
-                 ? (old & 0xffff) | (hsum << 16)
-                 : (old & 0xffff0000) | hsum;
-        old = atomicCAS(address_as_ui, assumed, old);
-
-    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
-    } while (assumed != old);
-}
-=============== End: Solution 1 for atomicAdd not support for (c10::Half *, c10::Half) ===============
-
-=============== Solution 2 for atomicAdd not support for (c10::Half *, c10::Half) ===============
-https://discuss.pytorch.org/t/c10-half-float-type-support-for-atomicadd/137628/2
-Use gpuAtomicAdd rather than atomicAdd:
-https://github.com/pytorch/pytorch/blob/085e2f7bddc45f859fcdb786926d60d709b2daa0/aten/src/ATen/cuda/Atomic.cuh#L181-L190
-=============== End: Solution 2 for atomicAdd not support for (c10::Half *, c10::Half) =============== 
-*/
-
+// Each block owns one (batch, channel) plane. Threads calculate grad_input
+// while reducing both channel-wise parameter gradients in shared memory.
+// Consequently, each block performs only two global atomic additions instead
+// of two atomic additions for every input element.
 template <typename scalar_t>
 __global__ void mpelu_backward_cuda_kernel(
-    const torch::PackedTensorAccessor<scalar_t,4,torch::RestrictPtrTraits,size_t> input,
-    const torch::PackedTensorAccessor<scalar_t,1,torch::RestrictPtrTraits,size_t> a,
-    const torch::PackedTensorAccessor<scalar_t,1,torch::RestrictPtrTraits,size_t> b,
-    const torch::PackedTensorAccessor<scalar_t,4,torch::RestrictPtrTraits,size_t> output,    
-    const torch::PackedTensorAccessor<scalar_t,4,torch::RestrictPtrTraits,size_t> grad_output,
-    torch::PackedTensorAccessor<scalar_t,4,torch::RestrictPtrTraits,size_t> grad_input,
-    torch::PackedTensorAccessor<scalar_t,1,torch::RestrictPtrTraits,size_t> grad_a,
-    torch::PackedTensorAccessor<scalar_t,1,torch::RestrictPtrTraits,size_t> grad_b,
-    const int width, const int height
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ alpha,
+    const scalar_t* __restrict__ beta,
+    const scalar_t* __restrict__ grad_output,
+    scalar_t* __restrict__ grad_input,
+    at::acc_type<scalar_t, true>* __restrict__ grad_alpha,
+    at::acc_type<scalar_t, true>* __restrict__ grad_beta,
+    int64_t channels,
+    int64_t spatial_size
 ) {
-    const int batch_idx = blockIdx.z;
-    const int channel_idx = blockIdx.y;
-    const int pixel_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    using acc_t = at::acc_type<scalar_t, true>;
+    extern __shared__ unsigned char shared_bytes[];
+    acc_t* shared_alpha = reinterpret_cast<acc_t*>(shared_bytes);
+    acc_t* shared_beta = shared_alpha + blockDim.x;
 
-    if (pixel_idx < width * height) {
-        int x = pixel_idx % width;
-        int y = pixel_idx / width;
+    const int64_t batch_channel = blockIdx.x;
+    const int64_t channel = batch_channel % channels;
+    const int64_t offset = batch_channel * spatial_size;
+    const acc_t alpha_value = static_cast<acc_t>(alpha[channel]);
+    const acc_t beta_value = static_cast<acc_t>(beta[channel]);
+    acc_t alpha_sum = acc_t(0);
+    acc_t beta_sum = acc_t(0);
 
-        const scalar_t inp = input[batch_idx][channel_idx][y][x];
-        const scalar_t oup = output[batch_idx][channel_idx][y][x];
-        const scalar_t grad_out = grad_output[batch_idx][channel_idx][y][x];
+    for (int64_t pixel = threadIdx.x; pixel < spatial_size;
+         pixel += blockDim.x) {
+        const int64_t index = offset + pixel;
+        const acc_t value = static_cast<acc_t>(input[index]);
+        const acc_t upstream = static_cast<acc_t>(grad_output[index]);
 
-        atomicAdd(&grad_a[channel_idx], grad_out * (inp <= 0) * (oup / a[channel_idx]));
-        atomicAdd(&grad_b[channel_idx], grad_out * (inp <= 0) * inp * (oup + a[channel_idx]));
-        grad_input[batch_idx][channel_idx][y][x] = grad_out * ( (inp > 0) + (inp <= 0) * b[channel_idx] * (oup + a[channel_idx]));
+        if (value <= acc_t(0)) {
+            const acc_t exponential = exp(beta_value * value);
+            alpha_sum += upstream * (exponential - acc_t(1));
+            beta_sum += upstream * alpha_value * value * exponential;
+            grad_input[index] = static_cast<scalar_t>(
+                upstream * alpha_value * beta_value * exponential
+            );
+        } else {
+            grad_input[index] = static_cast<scalar_t>(upstream);
+        }
+    }
+
+    shared_alpha[threadIdx.x] = alpha_sum;
+    shared_beta[threadIdx.x] = beta_sum;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            shared_alpha[threadIdx.x] += shared_alpha[threadIdx.x + stride];
+            shared_beta[threadIdx.x] += shared_beta[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+        gpuAtomicAdd(grad_alpha + channel, shared_alpha[0]);
+        gpuAtomicAdd(grad_beta + channel, shared_beta[0]);
     }
 }
 
+int get_forward_blocks(int64_t num_elements) {
+    // A capped grid works with the grid-stride loop and avoids launching a
+    // needlessly large number of blocks for very large feature maps.
+    constexpr int kMaxBlocks = 4096;
+    return static_cast<int>(std::min<int64_t>(
+        (num_elements + kThreads - 1) / kThreads, kMaxBlocks
+    ));
+}
 
-// ===================================================================
+}  // namespace
 
 torch::Tensor mpelu_forward_cuda(
     const torch::Tensor input,
-    const torch::Tensor a,
-    const torch::Tensor b
-){
+    const torch::Tensor alpha,
+    const torch::Tensor beta
+) {
+    c10::cuda::CUDAGuard device_guard(input.device());
+    auto output = torch::empty_like(input);
+    if (input.numel() == 0) {
+        return output;
+    }
 
-    torch::Tensor output = torch::zeros_like(input);
+    const int64_t channels = input.size(1);
+    const int64_t spatial_size = input.size(2) * input.size(3);
+    const int blocks = get_forward_blocks(input.numel());
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    const int threads_per_block = 256;
-    const int batch_size = input.size(0);
-    const int num_channels = input.size(1);
-    const int height = input.size(2);
-    const int width = input.size(3);
-
-    dim3 threadsPerBlock(threads_per_block);
-    dim3 numBlocks(
-        (width * height + threads_per_block - 1) / threads_per_block,
-        num_channels,
-        batch_size
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        input.scalar_type(), "mpelu_forward_cuda", [&] {
+            mpelu_forward_cuda_kernel<scalar_t><<<blocks, kThreads, 0, stream>>>(
+                input.data_ptr<scalar_t>(),
+                alpha.data_ptr<scalar_t>(),
+                beta.data_ptr<scalar_t>(),
+                output.data_ptr<scalar_t>(),
+                input.numel(),
+                channels,
+                spatial_size
+            );
+        }
     );
-    
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "mpelu_forward_cuda", ([&] {
-        mpelu_forward_cuda_kernel<scalar_t><<<numBlocks, threadsPerBlock>>>(
-            input.packed_accessor<scalar_t, 4, torch::RestrictPtrTraits, size_t>(),
-            a.packed_accessor<scalar_t, 1, torch::RestrictPtrTraits, size_t>(),
-            b.packed_accessor<scalar_t, 1, torch::RestrictPtrTraits, size_t>(),
-            output.packed_accessor<scalar_t, 4, torch::RestrictPtrTraits, size_t>(),
-            width, height
-        );
-    }));
-    
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return output;
 }
 
 void mpelu_backward_cuda(
     const torch::Tensor& input,
-    const torch::Tensor& a,
-    const torch::Tensor& b,
-    const torch::Tensor& output,
+    const torch::Tensor& alpha,
+    const torch::Tensor& beta,
     const torch::Tensor& grad_output,
     torch::Tensor& grad_input,
-    torch::Tensor& grad_a,
-    torch::Tensor& grad_b
-){
+    torch::Tensor& grad_alpha,
+    torch::Tensor& grad_beta
+) {
+    c10::cuda::CUDAGuard device_guard(input.device());
+    if (input.numel() == 0) {
+        return;
+    }
 
-    grad_input.zero_();
-    grad_a.zero_();
-    grad_b.zero_();
+    const int64_t channels = input.size(1);
+    const int64_t spatial_size = input.size(2) * input.size(3);
+    const int64_t batch_channels = input.size(0) * channels;
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    const int batch_size = grad_output.size(0);
-    const int num_channels = grad_output.size(1);
-    const int height = grad_output.size(2);
-    const int width = grad_output.size(3);
-
-    const int threads_per_block = 256;
-    dim3 threadsPerBlock(threads_per_block);
-    dim3 numBlocks(
-        (width * height + threads_per_block - 1) / threads_per_block,
-        num_channels,
-        batch_size
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        input.scalar_type(), "mpelu_backward_cuda", [&] {
+            using acc_t = at::acc_type<scalar_t, true>;
+            const size_t shared_memory = 2 * kThreads * sizeof(acc_t);
+            mpelu_backward_cuda_kernel<scalar_t>
+                <<<batch_channels, kThreads, shared_memory, stream>>>(
+                    input.data_ptr<scalar_t>(),
+                    alpha.data_ptr<scalar_t>(),
+                    beta.data_ptr<scalar_t>(),
+                    grad_output.data_ptr<scalar_t>(),
+                    grad_input.data_ptr<scalar_t>(),
+                    grad_alpha.data_ptr<acc_t>(),
+                    grad_beta.data_ptr<acc_t>(),
+                    channels,
+                    spatial_size
+                );
+        }
     );
-
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_output.type(), "mpelu_backward_cuda", ([&] {
-        mpelu_backward_cuda_kernel<scalar_t><<<numBlocks, threadsPerBlock>>>(
-            input.packed_accessor<scalar_t,4,torch::RestrictPtrTraits,size_t>(),
-            a.packed_accessor<scalar_t,1,torch::RestrictPtrTraits,size_t>(),
-            b.packed_accessor<scalar_t,1,torch::RestrictPtrTraits,size_t>(),
-            output.packed_accessor<scalar_t,4,torch::RestrictPtrTraits,size_t>(),
-            grad_output.packed_accessor<scalar_t,4,torch::RestrictPtrTraits,size_t>(),
-            grad_input.packed_accessor<scalar_t,4,torch::RestrictPtrTraits,size_t>(),
-            grad_a.packed_accessor<scalar_t,1,torch::RestrictPtrTraits,size_t>(),
-            grad_b.packed_accessor<scalar_t,1,torch::RestrictPtrTraits,size_t>(),
-            width, height
-        );
-    }));
-    
-};
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}

--- a/pytorch/setup.py
+++ b/pytorch/setup.py
@@ -19,8 +19,10 @@ setup(
             sources=sources,
             include_dirs=include_dirs,
             extra_compile_args={
-                'cxx': ['-O2'],
-                'nvcc': ['-O2', '-G', '-lineinfo']  # Add debug flags here
+                'cxx': ['-O3'],
+                # Keep line information for profiling without enabling CUDA's
+                # device-debug mode (-G), which disables key optimizations.
+                'nvcc': ['-O3', '-lineinfo']
             }
         )
     ],

--- a/pytorch/test_mpelu.py
+++ b/pytorch/test_mpelu.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import unittest
+
+import torch
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mpelu import MPELU  # noqa: E402
+
+
+def reference_mpelu(input, alpha, beta):
+    alpha = alpha.to(input.dtype).view(1, -1, 1, 1)
+    beta = beta.to(input.dtype).view(1, -1, 1, 1)
+    return torch.where(
+        input > 0,
+        input,
+        alpha * (torch.exp(beta * input) - 1),
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "MPELU extension requires CUDA")
+class MPELUCudaTest(unittest.TestCase):
+    def test_forward_and_backward_match_reference(self):
+        torch.manual_seed(7)
+        device = torch.device("cuda")
+        custom = MPELU(5).to(device=device, dtype=torch.float64)
+        alpha_ref = custom.alpha.detach().clone().requires_grad_()
+        beta_ref = custom.beta.detach().clone().requires_grad_()
+        input_custom = torch.randn(
+            3, 5, 7, 9, device=device, dtype=torch.float64, requires_grad=True
+        )
+        input_ref = input_custom.detach().clone().requires_grad_()
+        upstream = torch.randn_like(input_custom)
+
+        output_custom = custom(input_custom)
+        output_ref = reference_mpelu(input_ref, alpha_ref, beta_ref)
+        output_custom.backward(upstream)
+        output_ref.backward(upstream)
+
+        torch.testing.assert_close(output_custom, output_ref)
+        torch.testing.assert_close(input_custom.grad, input_ref.grad)
+        torch.testing.assert_close(custom.alpha.grad, alpha_ref.grad)
+        torch.testing.assert_close(custom.beta.grad, beta_ref.grad)
+
+    def test_channels_last_input(self):
+        device = torch.device("cuda")
+        module = MPELU(4).to(device)
+        input = torch.randn(2, 4, 8, 8, device=device).to(
+            memory_format=torch.channels_last
+        )
+        input.requires_grad_()
+
+        output = module(input)
+        output.sum().backward()
+
+        self.assertEqual(output.shape, input.shape)
+        self.assertIsNotNone(input.grad)
+        self.assertTrue(torch.isfinite(input.grad).all())
+
+    def test_zero_alpha_has_finite_gradients(self):
+        device = torch.device("cuda")
+        module = MPELU(3).to(device)
+        module.alpha.data.zero_()
+        input = -torch.rand(2, 3, 4, 4, device=device)
+        input.requires_grad_()
+
+        module(input).sum().backward()
+
+        self.assertTrue(torch.isfinite(module.alpha.grad).all())
+        self.assertTrue(torch.isfinite(module.beta.grad).all())
+        self.assertTrue(torch.isfinite(input.grad).all())
+
+    def test_half_input_accumulates_parameter_gradients_in_float(self):
+        device = torch.device("cuda")
+        module = MPELU(3).to(device)
+        input = torch.randn(
+            4, 3, 8, 8, device=device, dtype=torch.float16, requires_grad=True
+        )
+
+        module(input).float().sum().backward()
+
+        self.assertEqual(module.alpha.grad.dtype, torch.float32)
+        self.assertEqual(module.beta.grad.dtype, torch.float32)
+        self.assertTrue(torch.isfinite(module.alpha.grad).all())
+        self.assertTrue(torch.isfinite(module.beta.grad).all())
+
+    def test_uses_current_stream(self):
+        device = torch.device("cuda")
+        module = MPELU(3).to(device)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+
+        with torch.cuda.stream(stream):
+            input = torch.randn(4, 3, 16, 16, device=device, requires_grad=True)
+            output = module(input)
+            output.sum().backward()
+        torch.cuda.current_stream().wait_stream(stream)
+
+        self.assertTrue(torch.isfinite(output).all())
+        self.assertTrue(torch.isfinite(input.grad).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Optimize the PyTorch CUDA implementation of channel-wise MPELU while preserving its existing semantics: each input channel owns one learnable `alpha` and one learnable `beta`.

## Root cause

The PyTorch implementation had two independent, high-impact GPU performance problems:

1. The extension was compiled with NVCC `-G`. This emits device debug code and suppresses important CUDA optimizations even though `-O2` was also supplied.
2. The backward kernel issued two global atomic additions for every input element. All `N * H * W` elements in a channel contended on the same `grad_alpha[channel]` and `grad_beta[channel]` addresses. Caffe and Torch7 instead use staged reductions.

There were also secondary problems:

- kernels launched on the default CUDA stream instead of PyTorch's current stream;
- no CUDA device guard or launch-error check;
- forward output was zero-filled before being completely overwritten;
- backward buffers were zeroed in both Python and CUDA;
- inline `.contiguous()` calls on output buffers could create temporary tensors that received the kernel writes;
- the 4D accessor/grid layout wasted threads on small feature maps and did more index arithmetic than necessary;
- `grad_alpha` used `output / alpha`, which is unstable and divides by zero when `alpha == 0`;
- half-precision parameter gradients accumulated in half precision.

## What changed

- remove NVCC `-G`, retain `-lineinfo`, and build optimized code with `-O3`;
- flatten forward traversal into a capped grid-stride kernel;
- assign one backward block to each `(batch, channel)` plane;
- reduce both parameter gradients in shared memory and issue only two global atomics per block;
- reduce per-channel global atomic traffic from `2 * N * H * W` to `2 * N`;
- accumulate FP16/FP32 parameter gradients in FP32, and FP64 gradients in FP64;
- calculate derivatives directly from `exp(beta * input)`, removing the `output / alpha` dependency;
- launch on `at::cuda::getCurrentCUDAStream()` with a CUDA device guard and launch checks;
- use `empty_like` for fully overwritten output/grad-input tensors;
- normalize contiguous inputs before entering the extension and never write into temporary contiguous output copies;
- stop saving the forward output for backward;
- validate tensor rank, channel-wise parameter shape, dtype, device, and gradient buffers at the C++ boundary.

## Correctness coverage

Added CUDA unit tests for:

- forward and backward agreement with a native PyTorch reference;
- channel-wise alpha/beta gradients;
- channels-last input handling;
- finite gradients when `alpha == 0`;
- FP16 compute with FP32 parameter-gradient accumulation;
- execution on a non-default CUDA stream.

## Validation performed

- `git diff --check`
- Python syntax compilation for `mpelu.py`, `setup.py`, and `test_mpelu.py`
- independent central finite-difference validation of the input, alpha, and beta derivatives over 1,000 random samples; maximum absolute error was approximately `4.2e-10`

CUDA compilation, GPU unit tests, and performance profiling could not be run on the authoring machine because it is macOS arm64 without PyTorch, CUDA, or NVCC. The PR remains a draft until it is built and benchmarked on the documented Ubuntu/CUDA environment.